### PR TITLE
Remove deprecated service accounts API endpoints

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -473,24 +473,6 @@ export interface Token {
   scope?: string;
 }
 
-export interface ServiceAccountInput {
-  name: string;
-}
-
-export interface ServiceAccount {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  name: string;
-  clientId: string;
-  clientSecret: string;
-}
-
-export interface ServiceAccountsListResult {
-  total: number;
-  data: ServiceAccount[];
-}
-
 /**
  * Teams
  */

--- a/src/api/yepcodeApi.ts
+++ b/src/api/yepcodeApi.ts
@@ -35,9 +35,6 @@ import {
   StorageObject,
   CreateStorageObjectInput,
   Token,
-  ServiceAccountInput,
-  ServiceAccount,
-  ServiceAccountsListResult,
   Sandbox,
   CreateSandboxInput,
   UpdateSandboxInput,
@@ -806,20 +803,6 @@ export class YepCodeApi {
         "x-api-token": apiToken,
       },
     });
-  }
-
-  async getAllServiceAccounts(): Promise<ServiceAccountsListResult> {
-    return this.request("GET", "/auth/service-accounts");
-  }
-
-  async createServiceAccount(
-    data: ServiceAccountInput
-  ): Promise<ServiceAccount> {
-    return this.request("POST", "/auth/service-accounts", { data });
-  }
-
-  async deleteServiceAccount(id: string): Promise<void> {
-    return this.request("DELETE", `/auth/service-accounts/${id}`);
   }
 
   // Team endpoints


### PR DESCRIPTION
## Summary

- Remove `getAllServiceAccounts`, `createServiceAccount`, and `deleteServiceAccount` methods from `YepCodeApi`
- Drop the corresponding `ServiceAccountInput`, `ServiceAccount`, and `ServiceAccountsListResult` types from `types.ts`
- These endpoints (`GET/POST /auth/service-accounts`, `DELETE /auth/service-accounts/{id}`) are being removed from the YepCode Cloud API

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] Confirm no remaining references to removed methods or types

🤖 Generated with [Claude Code](https://claude.com/claude-code)