### PR TITLE
Add createSignedUrl to storage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ const processes = await api.getProcesses();
 
 ### 6. Storage Objects
 
-You can manage files in your YepCode workspace using the `YepCodeStorage` class. This allows you to upload, list, download, and delete files easily.
+You can manage files in your YepCode workspace using the `YepCodeStorage` class. This allows you to upload, list, download, delete, and generate signed URLs for files easily.
 
 ```js
 const { YepCodeStorage } = require('@yepcode/run');
@@ -125,6 +125,12 @@ console.log(files);
 // Download a file
 const stream = await storage.download('path/myfile.txt');
 stream.pipe(fs.createWriteStream('./downloaded.txt'));
+
+// Create a temporary signed URL (1 hour by default)
+const signedUrl = await storage.createSignedUrl('path/myfile.txt', {
+  expiresInSeconds: 300 // Optional
+});
+console.log(signedUrl.url, signedUrl.expiresAt);
 
 // Delete a file
 await storage.delete('myfile.txt');
@@ -392,9 +398,33 @@ interface Process {
 }
 ```
 
+##### `createSignedUrl(data: CreateSignedUrlInput): Promise<SignedUrl>`
+
+Creates a temporary signed URL for a stored file.
+
+**Parameters:**
+
+- `data.path`: Storage path (filename) to generate a signed URL for
+- `data.expiresInSeconds`: Optional expiry in seconds
+
+**Returns:** Promise<SignedUrl>
+
+```typescript
+interface CreateSignedUrlInput {
+  path: string;
+  expiresInSeconds?: number;
+}
+
+interface SignedUrl {
+  url: string;
+  path: string;
+  expiresAt: string;
+}
+```
+
 ### YepCodeStorage
 
-Manages file storage in your YepCode workspace. Allows you to upload, list, download, and delete files using the YepCode API.
+Manages file storage in your YepCode workspace. Allows you to upload, list, download, delete, and generate signed URLs using the YepCode API.
 
 #### Constructor
 
@@ -434,6 +464,14 @@ Deletes a file from YepCode storage.
 - `filename`: Name of the file to delete
 - **Returns:** Promise<void>
 
+##### `createSignedUrl(filename: string, options?: { expiresInSeconds?: number }): Promise<SignedUrl>`
+
+Creates a temporary signed URL for a file in storage.
+
+- `filename`: Name of the file to generate a signed URL for
+- `options.expiresInSeconds`: Optional expiry in seconds
+- **Returns:** Promise<SignedUrl>
+
 ##### `StorageObject`
 
 ```typescript
@@ -443,6 +481,16 @@ interface StorageObject {
   size?: number;
   contentType?: string;
   createdAt?: string;
+}
+```
+
+##### `SignedUrl`
+
+```typescript
+interface SignedUrl {
+  url: string;
+  path: string;
+  expiresAt: string;
 }
 ```
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -463,6 +463,17 @@ export type CreateStorageObjectInput = {
   file: File | Blob | Readable;
 };
 
+export type CreateSignedUrlInput = {
+  path: string;
+  expiresInSeconds?: number;
+};
+
+export type SignedUrl = {
+  url: string;
+  path: string;
+  expiresAt: string;
+};
+
 /**
  * Auth
  */

--- a/src/api/yepcodeApi.ts
+++ b/src/api/yepcodeApi.ts
@@ -34,6 +34,8 @@ import {
   VersionedModuleAliasesPaginatedResult,
   StorageObject,
   CreateStorageObjectInput,
+  CreateSignedUrlInput,
+  SignedUrl,
   Token,
   Sandbox,
   CreateSandboxInput,
@@ -794,6 +796,10 @@ export class YepCodeApi {
       "DELETE",
       `/storage/objects/${encodeURIComponent(filename)}`
     );
+  }
+
+  async createSignedUrl(data: CreateSignedUrlInput): Promise<SignedUrl> {
+    return this.request("POST", "/storage/signed-urls", { data });
   }
 
   // Auth endpoints

--- a/src/storage/yepcodeStorage.ts
+++ b/src/storage/yepcodeStorage.ts
@@ -1,5 +1,5 @@
 import { YepCodeApi } from "../api";
-import { StorageObject, YepCodeApiConfig } from "../api/types";
+import { SignedUrl, StorageObject, YepCodeApiConfig } from "../api/types";
 import { Readable } from "stream";
 
 export class YepCodeStorage {
@@ -26,5 +26,12 @@ export class YepCodeStorage {
 
   async delete(filename: string): Promise<void> {
     await this.api.deleteObject(filename);
+  }
+
+  async createSignedUrl(
+    filename: string,
+    options: { expiresInSeconds?: number } = {}
+  ): Promise<SignedUrl> {
+    return this.api.createSignedUrl({ path: filename, ...options });
   }
 }

--- a/tests/api/yepcodeApi.storage.test.ts
+++ b/tests/api/yepcodeApi.storage.test.ts
@@ -1,5 +1,5 @@
-import { YepCodeApi } from "../../src/api/yepcodeApi";
-import { StorageObject } from "../../src/api/types";
+import { YepCodeApi, YepCodeApiError } from "../../src/api/yepcodeApi";
+import { SignedUrl, StorageObject } from "../../src/api/types";
 import fs, { createWriteStream, readFileSync } from "fs";
 import path from "path";
 import { Readable } from "stream";
@@ -111,6 +111,70 @@ describe.skip("YepCodeApi", () => {
       const result: Readable = await api.getObject(testName);
 
       await verifyDownloadedFile(result, downloadedFile, testFilePath);
+    });
+  });
+
+  describe("createSignedUrl", () => {
+    it("should return a signed url with the default expiry", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await api.createObject({ name: testName, file });
+
+      const result: SignedUrl = await api.createSignedUrl({ path: testName });
+
+      expect(typeof result.url).toBe("string");
+      expect(result.url.length).toBeGreaterThan(0);
+      expect(result.path).toBe(testName);
+
+      const expiresAt = new Date(result.expiresAt).getTime();
+      const expectedExpiry = Date.now() + 3600 * 1000;
+      expect(Math.abs(expiresAt - expectedExpiry)).toBeLessThan(60 * 1000);
+    });
+
+    it("should return a signed url with a custom expiry", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await api.createObject({ name: testName, file });
+
+      const result: SignedUrl = await api.createSignedUrl({
+        path: testName,
+        expiresInSeconds: 60,
+      });
+
+      const expiresAt = new Date(result.expiresAt).getTime();
+      const expectedExpiry = Date.now() + 60 * 1000;
+      expect(Math.abs(expiresAt - expectedExpiry)).toBeLessThan(30 * 1000);
+    });
+
+    it("should return content matching the original file when fetched", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await api.createObject({ name: testName, file });
+
+      const { url } = await api.createSignedUrl({ path: testName });
+
+      const response = await fetch(url);
+      expect(response.ok).toBe(true);
+      const body = await response.text();
+      expect(body).toBe(readFileSync(testFilePath, "utf8"));
+    });
+
+    it("should throw a 404 when the file does not exist", async () => {
+      await expect(
+        api.createSignedUrl({ path: "does-not-exist.txt" })
+      ).rejects.toMatchObject({
+        name: "YepCodeApiError",
+        status: 404,
+      } as Partial<YepCodeApiError>);
+    });
+
+    it("should throw a 400 when expiresInSeconds is out of range", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await api.createObject({ name: testName, file });
+
+      await expect(
+        api.createSignedUrl({ path: testName, expiresInSeconds: 999999 })
+      ).rejects.toMatchObject({
+        name: "YepCodeApiError",
+        status: 400,
+      } as Partial<YepCodeApiError>);
     });
   });
 });

--- a/tests/storage/yepcodeStorage.test.ts
+++ b/tests/storage/yepcodeStorage.test.ts
@@ -1,5 +1,6 @@
 import { YepCodeStorage } from "../../src/storage";
-import { StorageObject } from "../../src/api/types";
+import { YepCodeApiError } from "../../src/api/yepcodeApi";
+import { SignedUrl, StorageObject } from "../../src/api/types";
 import fs, { createWriteStream, readFileSync } from "fs";
 import path from "path";
 import { Readable } from "stream";
@@ -115,6 +116,57 @@ describe.skip("YepCodeStorage", () => {
       const result: Readable = await storage.download(testName);
 
       await verifyDownloadedFile(result, downloadedFile, testFilePath);
+    });
+  });
+
+  describe("createSignedUrl", () => {
+    it("should return a signed url with the default expiry", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await storage.upload(testName, file);
+
+      const result: SignedUrl = await storage.createSignedUrl(testName);
+
+      expect(typeof result.url).toBe("string");
+      expect(result.url.length).toBeGreaterThan(0);
+      expect(result.path).toBe(testName);
+
+      const expiresAt = new Date(result.expiresAt).getTime();
+      const expectedExpiry = Date.now() + 3600 * 1000;
+      expect(Math.abs(expiresAt - expectedExpiry)).toBeLessThan(60 * 1000);
+    });
+
+    it("should return a signed url with a custom expiry", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await storage.upload(testName, file);
+
+      const result: SignedUrl = await storage.createSignedUrl(testName, {
+        expiresInSeconds: 60,
+      });
+
+      const expiresAt = new Date(result.expiresAt).getTime();
+      const expectedExpiry = Date.now() + 60 * 1000;
+      expect(Math.abs(expiresAt - expectedExpiry)).toBeLessThan(30 * 1000);
+    });
+
+    it("should throw a 404 when the file does not exist", async () => {
+      await expect(
+        storage.createSignedUrl("does-not-exist.txt")
+      ).rejects.toMatchObject({
+        name: "YepCodeApiError",
+        status: 404,
+      } as Partial<YepCodeApiError>);
+    });
+
+    it("should throw a 400 when expiresInSeconds is out of range", async () => {
+      const file: File = new File([readFileSync(testFilePath)], testName);
+      await storage.upload(testName, file);
+
+      await expect(
+        storage.createSignedUrl(testName, { expiresInSeconds: 999999 })
+      ).rejects.toMatchObject({
+        name: "YepCodeApiError",
+        status: 400,
+      } as Partial<YepCodeApiError>);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Wrap the new `POST /api/:team/rest/storage/signed-urls` endpoint (yepcode-storage-api [#11](https://github.com/yepcode/yepcode-storage-api/pull/11)) on both `YepCodeApi` and `YepCodeStorage`.
- `YepCodeApi.createSignedUrl({ path, expiresInSeconds? })` posts to the endpoint; `YepCodeStorage.createSignedUrl(filename, { expiresInSeconds? })` is the higher-level wrapper that mirrors `upload`/`download`/`delete`.
- Returns the full `{ url, path, expiresAt }` object so callers can read the expiry without tracking the value they passed in.
- Adds new `CreateSignedUrlInput` and `SignedUrl` types, exported via the existing `src/api/types.ts` re-exports.

## Test plan
- [x] `npm run build` (clean)
- [ ] `npm test` against an environment that has yepcode-storage-api PR #11 deployed — un-skip the new `createSignedUrl` describe blocks in `tests/api/yepcodeApi.storage.test.ts` and `tests/storage/yepcodeStorage.test.ts` and verify:
  - default expiry (~1h)
  - custom `expiresInSeconds`
  - fetched signed URL returns the original file content
  - 404 for missing file
  - 400 for out-of-range `expiresInSeconds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)